### PR TITLE
Add Spifly headers

### DIFF
--- a/braille-utils.api/build.gradle
+++ b/braille-utils.api/build.gradle
@@ -65,7 +65,7 @@ bundle {
     instructions << [
      	//must use file() to resolve against the build.gradle in Eclipse
         "-include": file('bnd.bnd'),
-        "SPI-Provider": "javax.imageio.spi.ServiceRegistry"
+        "SPI-Provider": "javax.imageio.spi.ServiceRegistry",
         "SPI-Consumer": "javax.imageio.spi.ServiceRegistry#lookupProviders(java.lang.Class)",
         'Repository-Revision': "$repositoryRevision"
     ]

--- a/braille-utils.api/build.gradle
+++ b/braille-utils.api/build.gradle
@@ -65,6 +65,8 @@ bundle {
     instructions << [
      	//must use file() to resolve against the build.gradle in Eclipse
         "-include": file('bnd.bnd'),
+        "SPI-Provider": "javax.imageio.spi.ServiceRegistry"
+        "SPI-Consumer": "javax.imageio.spi.ServiceRegistry#lookupProviders(java.lang.Class)",
         'Repository-Revision': "$repositoryRevision"
     ]
 }

--- a/braille-utils.impl/build.gradle
+++ b/braille-utils.impl/build.gradle
@@ -72,5 +72,6 @@ bundle {
     instructions << [
      	//must use file() to resolve against the build.gradle in Eclipse
         "-include": file('bnd.bnd'),
+        "SPI-Provider": "javax.imageio.spi.ServiceRegistry"
     ]
 }


### PR DESCRIPTION
as a temporary solution for making the bundles work in an OSGi context.
