### PR TITLE
Fix Javadoc strings to make javadoc generation succeed on JDK8

### DIFF
--- a/braille-utils.api/src/org/daisy/braille/api/embosser/PrintPage.java
+++ b/braille-utils.api/src/org/daisy/braille/api/embosser/PrintPage.java
@@ -51,11 +51,11 @@ public class PrintPage implements Dimensions {
 	 */
 	public enum Shape {
 		/**
-		 *  Represents portrait shape, that is to say that getWidth()<getHeight()
+		 *  Represents portrait shape, that is to say that getWidth()&lt;getHeight()
 		 */
 		PORTRAIT,
 		/**
-		 *  Represents landscape shape, that is to say that getWidth>getHeight()
+		 *  Represents landscape shape, that is to say that getWidth&gt;getHeight()
 		 */
 		LANDSCAPE,
 		/**

--- a/braille-utils.impl/src/org/daisy/braille/impl/table/AdvancedBrailleConverter.java
+++ b/braille-utils.impl/src/org/daisy/braille/impl/table/AdvancedBrailleConverter.java
@@ -49,7 +49,7 @@ public class AdvancedBrailleConverter implements BrailleConverter {
 	 * @param replacement the replacement character, must be in the range 0x2800-0x283F
 	 * @param ignoreCase set to true to ignore character case
 	 * @param mode the match mode to use
-	 * @throws throws IllegalArgumentException if the table length isn't equal to 64
+	 * @throws IllegalArgumentException if the table length isn't equal to 64
 	 */
 	public AdvancedBrailleConverter(String[] table, Charset charset, EightDotFallbackMethod fallback, char replacement, boolean ignoreCase, MatchMode mode) {
 		this(table, charset, fallback, replacement, ignoreCase, false, mode);
@@ -63,7 +63,7 @@ public class AdvancedBrailleConverter implements BrailleConverter {
 	 * @param charset the preferred charset as defined in the BrailleConverter interface
 	 * @param ignoreCase set to true to ignore character case
 	 * @param mode the match mode to use
-	 * @throws throws IllegalArgumentException if the table length isn't equal to 256
+	 * @throws IllegalArgumentException if the table length isn't equal to 256
 	 */
 	public AdvancedBrailleConverter(String[] table, Charset charset, boolean ignoreCase, MatchMode mode) {
 		this(table, charset, EightDotFallbackMethod.MASK, null, ignoreCase, true, mode);

--- a/braille-utils.impl/src/org/daisy/braille/impl/table/EmbosserBrailleConverter.java
+++ b/braille-utils.impl/src/org/daisy/braille/impl/table/EmbosserBrailleConverter.java
@@ -47,7 +47,7 @@ public class EmbosserBrailleConverter implements BrailleConverter {
 	 * @param fallback the fallback method to use when encountering a character in the range 0x2840-0x28FF
 	 * @param replacement the replacement character, must be in the range 0x2800-0x283F
 	 * @param ignoreCase set to true to ignore character case
-	 * @throws throws IllegalArgumentException if the table length isn't equal to 64 or 256.
+	 * @throws IllegalArgumentException if the table length isn't equal to 64 or 256.
 	 */
 	public EmbosserBrailleConverter(String table, Charset charset, EightDotFallbackMethod fallback, char replacement, boolean ignoreCase) {
 		this(table, charset, fallback, replacement, ignoreCase, null);
@@ -61,7 +61,7 @@ public class EmbosserBrailleConverter implements BrailleConverter {
 	 * @param replacement the replacement character, must be in the range 0x2800-0x283F
 	 * @param ignoreCase set to true to ignore character case
 	 * @param t2bSupplements additional substitutions for text to braille translation. Values MUST be braille characters.
-	 * @throws throws IllegalArgumentException if the table length isn't equal to 64 or 256 or if supplements values are not braille characters.
+	 * @throws IllegalArgumentException if the table length isn't equal to 64 or 256 or if supplements values are not braille characters.
 	 */
 	public EmbosserBrailleConverter(String table, Charset charset, EightDotFallbackMethod fallback, char replacement, boolean ignoreCase, Map<Character, Character> t2bSupplements) {
 		char[] tableDef = table.toCharArray();

--- a/braille-utils.pef-tools/src/org/daisy/braille/pef/PrinterDevice.java
+++ b/braille-utils.pef-tools/src/org/daisy/braille/pef/PrinterDevice.java
@@ -94,7 +94,6 @@ public class PrinterDevice implements Device {
 	/**
 	 * Transmit a file to the device
 	 * @param file the file to transmit
-	 * @throws FileNotFoundException
 	 * @throws PrintException
 	 */
 	public void transmit(File file) throws PrintException {


### PR DESCRIPTION
While at it, maybe also update the docs to match the code. That is, add missing `@param` and `@returns` tags, add missing param and throws descriptions, etc.
TODO: fix warnings.
